### PR TITLE
Update Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ GEM
       execjs
     coffee-script-source (1.11.1)
     colorator (1.1.0)
-    commonmarker (0.17.13)
+    commonmarker (>= 0.23.4)
       ruby-enum (~> 0.5)
     concurrent-ruby (1.1.9)
     dnsruby (1.61.9)


### PR DESCRIPTION
Fixes security issue: Integer overflow in cmark-gfm table parsing extension leads to heap memory corruption
https://github.com/Pluggable-Transports/Pluggable-Transports-website/security/dependabot/7